### PR TITLE
overriding exit function to catch errors without exiting in julia

### DIFF
--- a/interfaces/julia/CMakeLists.txt
+++ b/interfaces/julia/CMakeLists.txt
@@ -1,8 +1,14 @@
 set(SRCJULIAIF dace_julia.cxx)
 
+option(CUSTOM_EXIT "Use a custom exit function in the Julia interface" OFF)
+
 add_library(dacejulia OBJECT ${SRCJULIAIF})
 set_target_properties(dacejulia PROPERTIES POSITION_INDEPENDENT_CODE True)
 target_link_libraries(dacejulia PUBLIC JlCxx::cxxwrap_julia)
 if(WIN32)
     target_compile_definitions(dacejulia PRIVATE "DACE_API=__declspec(dllexport)")
 endif(WIN32)
+if(CUSTOM_EXIT)
+    message(STATUS "Enabling custom exit function")
+    target_compile_definitions(dacejulia PRIVATE "CUSTOM_EXIT")
+endif(CUSTOM_EXIT)

--- a/interfaces/julia/dace_julia.cxx
+++ b/interfaces/julia/dace_julia.cxx
@@ -1,6 +1,8 @@
 #include "dace/AlgebraicVector.h"
 #include "dace/DA.h"
 #include <iostream>
+#include <stdexcept>
+#include <cstdlib>
 #include <jlcxx/jlcxx.hpp>
 #include <jlcxx/stl.hpp>
 #include <jlcxx/tuple.hpp>
@@ -19,6 +21,16 @@
 #define EVAL_SCALAR(T, U) \
     mod.method("evalScalar", [](const T& obj, const U& arg) { return obj.evalScalar(arg); }, \
             "Evaluation of `arg1` with a single arithmetic type argument, `arg2`.");
+
+
+// override the exit command (mainly so that the code doesn't exit when init isn't called first)
+// not sure how portable or safe this is so has to be enabled in cmake with -DCUSTOM_EXIT=ON
+#ifdef CUSTOM_EXIT
+void exit(int code) {
+    // TODO: should treat code==0 differently?
+    throw std::runtime_error("Caught exit call (code=" + std::to_string(code) + ")");
+}
+#endif
 
 
 JLCXX_MODULE define_julia_module(jlcxx::Module& mod) {


### PR DESCRIPTION
adds a new option to cmake which is disabled by default, add `-DCUSTOM_EXIT=ON` to enable